### PR TITLE
Support rotated rectangles

### DIFF
--- a/client.py
+++ b/client.py
@@ -25,6 +25,7 @@ def normalize_deg_y(deg):
     return round((deg+180)*10**decimal_places)
 
 def evaluate_response(public_key, private_key, response):
+    print('  evaluation of aligned geofence')
     # rebuild the encrypted numbers with our public key
     data = response.json()
     e_south_border_distance = paillier.EncryptedNumber(public_key, int(data['lat']))
@@ -43,13 +44,13 @@ def evaluate_response(public_key, private_key, response):
     match_y = north_border_distance >= 0 and south_border_distance <= 0
 
     if match_x and match_y:
-        print('Position is in Colorado')
+        print('    Position is in Colorado')
     elif match_x:
-        print('Position is in between longitude boundaries')
+        print('    Position is in between longitude boundaries')
     elif match_y:
-        print('Position is in between latitude boundaries')
+        print('    Position is in between latitude boundaries')
     else:
-        print('Position is elsewhere')
+        print('    Position is elsewhere')
 
 def send_to_server(x, y, public_key):
     encrypted_lat = public_key.encrypt(normalize_deg_x(x))
@@ -57,7 +58,6 @@ def send_to_server(x, y, public_key):
     return requests.get("http://127.0.0.1:5000/calculate?g="+str(public_key.g)+"&n="+str(public_key.n)+"&lat="+str(encrypted_lat.ciphertext())+"&lng="+str(encrypted_lng.ciphertext()))
 
 if __name__ == '__main__':
-    # generate a small paillier keypair
     public_key, private_key = paillier.generate_paillier_keypair(n_length=1024)
     print('testing position outside all boundaries')
     response_outside = send_to_server(outside_all_boundaries_x, outside_all_boundaries_y, public_key)

--- a/server.py
+++ b/server.py
@@ -5,6 +5,7 @@ import flask
 from flask import request
 from phe import paillier
 from random import random
+from vectors import Vec2, dot_product
 
 app = flask.Flask(__name__)
 
@@ -48,6 +49,50 @@ def calculate_geo():
       "lng": str(lngoffset.ciphertext()),
       "lng2": str(lngoffset2.ciphertext()),
     })
+
+@app.route('/calculate_rotated')
+def calculate_rotated():
+    # rebuild public key
+    g = int(request.args.get('g'))
+    n = int(request.args.get('n'))
+    # g = n+1 in the used implementation
+    pubkey = paillier.PaillierPublicKey(n=n)
+
+    # load the coordinate P(lat|lng) as EncryptedNumbers
+    P_lat = paillier.EncryptedNumber(pubkey, int(request.args.get('lat')))
+    P_lng = paillier.EncryptedNumber(pubkey, int(request.args.get('lng')))
+
+    # calculate values
+    # E(AP*AB), AB**2, E(AP*AD), AD**2
+    A = Vec2(geobox[1], geobox[0])
+    B = Vec2(geobox[1], geobox[2])
+    C = Vec2(geobox[3], geobox[2])
+    D = Vec2(geobox[3], geobox[0])
+
+    AB = B - A
+    AD = D - A
+
+    e_A_lat = pubkey.encrypt(A.x)
+    e_A_lng = pubkey.encrypt(A.y)
+    e_B_lat = pubkey.encrypt(B.x)
+    e_B_lng = pubkey.encrypt(B.y)
+
+    e_AP_lat = P_lat - e_A_lat
+    e_AP_lng = P_lng - e_A_lng
+
+    e_AP_dot_AB = (e_AP_lat * AB.x) + (e_AP_lng * AB.y)
+    e_AP_dot_AD = (e_AP_lat * AD.x) + (e_AP_lng * AD.y)
+
+    sq_AB = dot_product(AB, AB)
+    sq_AD = dot_product(AD, AD)
+
+    return json.dumps({
+        "e_AP_dot_AB": str(e_AP_dot_AB.ciphertext()),
+        "sq_AB": str(sq_AB),
+        "e_AP_dot_AD": str(e_AP_dot_AD.ciphertext()),
+        "sq_AD": str(sq_AD)
+    })
+
 
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', 5000))

--- a/vectors.py
+++ b/vectors.py
@@ -1,0 +1,78 @@
+import math
+
+
+class Vec2(object):
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+    def __neg__(self):
+        return Vec2(-self.x, -self.y)
+
+    def __add__(self, other):
+        return Vec2(self.x + other.x, self.y + other.y)
+
+    def __sub__(self, other):
+        return Vec2(self.x - other.x, self.y - other.y)
+
+    def __mul__(self, other):
+        if isinstance(other, int) or isinstance(other, float):
+            return Vec2(self.x * other, self.y * other)
+        elif isinstance(other, Vec2):
+            return Vec2(self.x * other.x, self.y * other.y)
+        else:
+            raise(TypeError("Can only multiply by a scalar (int or float) or another Vec2"))
+
+    def __truediv__(self, other):
+        if isinstance(other, int) or isinstance(other, float):
+            return Vec2(self.x / other, self.y / other)
+        elif isinstance(other, Vec2):
+            return Vec2(self.x / other.x, self.y / other.y)
+        else:
+            raise(TypeError("Can only divide by a scalar (int or float) or another Vec2"))
+
+    def __abs__(self):
+        return math.sqrt(self.x**2 + self.y**2)
+
+    def normalize(self):
+        return self/(abs(self))
+
+    def translate(self, vec):
+        return self + vec
+
+    def rotate(self, angle):
+        return Vec2(
+            self.x * math.cos(angle) - self.y * math.sin(angle),
+            self.x * math.sin(angle) + self.y * math.cos(angle)
+        )
+
+    def rotate_neg(self, angle):
+        return Vec2(
+            self.x * math.cos(angle) + self.y * math.sin(angle),
+            self.x * (-math.sin(angle)) + self.y * math.cos(angle)
+        )
+
+    def rotate_around(self, pivot, angle, neg=False):
+        translated_vec = self.translate(-pivot)
+        if neg is False:
+            rotated_vec = translated_vec.rotate(angle)
+        else:
+            rotated_vec = translated_vec.rotate_neg(angle)
+        return rotated_vec.translate(pivot)
+
+    def __str__(self):
+        return "(" + str(self.x) + "|" + str(self.y) + ")"
+
+
+def dot_product(vec_a, vec_b):
+    if not isinstance(vec_a, Vec2) or not isinstance(vec_b, Vec2):
+        raise TypeError("Dot product can only be calculated with two Vec2")
+    return vec_a.x * vec_b.x + vec_a.y * vec_b.y
+
+
+def get_angle(vec_a, vec_b):
+    if not isinstance(vec_a, Vec2) or not isinstance(vec_b, Vec2):
+        raise TypeError("Angle calculation can only be done with two Vec2")
+    vec_a = vec_a.normalize()
+    vec_b = vec_b.normalize()
+    return math.acos(dot_product(vec_a, vec_b) / (abs(vec_a) * abs(vec_b)))


### PR DESCRIPTION
Hello, it is me again.

I added support for arbitrary rotated rectangular Geofences. This is done by homomorphically calculating the perpendicular projection of the point onto two non-opposing borders and comparing whether the length of the resulting vectors are not longer than the respective borders are. Mathematical proof can be found in [this paper](https://arxiv.org/abs/1804.09933) under section IV-Implementation.

To be more consistent with the mathematical descriptions in the paper I used a small vector class, which is a little bloated from other things that were tested with it.
The prefix `e_` indicates a homomorphically encrypted value.

With this it should be possible to evaluate triangles (taking a detour) by combining two rectangular Geofences.